### PR TITLE
Add inner-mod API to copy settings between chests

### DIFF
--- a/ConvenientChests/ConvenientChests.csproj
+++ b/ConvenientChests/ConvenientChests.csproj
@@ -123,6 +123,7 @@
     <Compile Include="Module.cs" />
     <Compile Include="StackToNearbyChests\StackLogic.cs" />
     <Compile Include="StackToNearbyChests\StashToNearbyChestsModule.cs" />
+    <Compile Include="ModAPI.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="manifest.json">

--- a/ConvenientChests/ModAPI.cs
+++ b/ConvenientChests/ModAPI.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using ConvenientChests.CategorizeChests.Framework;
+using StardewModdingAPI;
+using StardewValley.Objects;
+
+namespace ConvenientChests {
+    public class ModAPI {
+        public void CopyChestData(Chest source, Chest target) {
+            IChestDataManager chestDataManager = ModEntry.CategorizeChests.ChestDataManager;
+            ChestData sourceData = chestDataManager.GetChestData(source);
+            ChestData targetData = chestDataManager.GetChestData(target);
+            targetData.AcceptedItemKinds.Clear();
+            foreach (var itemKey in sourceData.AcceptedItemKinds) {
+                targetData.AddAccepted(itemKey);
+            }
+        }
+    }
+}

--- a/ConvenientChests/ModEntry.cs
+++ b/ConvenientChests/ModEntry.cs
@@ -25,6 +25,7 @@ namespace ConvenientChests {
 
             helper.Events.GameLoop.SaveLoaded      += (sender, e) => LoadModules();
             helper.Events.GameLoop.ReturnedToTitle += (sender, e) => UnloadModules();
+
         }
 
         private void LoadModules() {
@@ -44,12 +45,16 @@ namespace ConvenientChests {
         private void UnloadModules() {
             StashNearby.Deactivate();
             StashNearby = null;
-            
+
             CategorizeChests.Deactivate();
             CategorizeChests = null;
-            
+
             CraftFromChests.Deactivate();
             CraftFromChests = null;
+        }
+
+        public override object GetApi() {
+            return new ModAPI();
         }
     }
 }

--- a/ConvenientChests/manifest.json
+++ b/ConvenientChests/manifest.json
@@ -1,7 +1,7 @@
 {
   "Name": "Convenient Chests",
   "Author": "aEnigma",
-  "Version": "1.1.0",
+  "Version": "1.1.1",
   "Description": "Makes your life easier: Allows crafting from and auto-stashing to nearby chests.",
   "UniqueID": "aEnigma.ConvenientChests",
   "MinimumApiVersion": "2.10.2",


### PR DESCRIPTION
This is needed for MegaStorage, which adds custom chests. During saving, these are replaced with the default chests, which causes the categories not to be saved. This API makes it possible to resolve this.

This is part of resolving the bug "Categories for Large Chest and Magic Chest (Mega Storage mod) aren't saved" on the Nexus tracker.